### PR TITLE
Ignore Test Files

### DIFF
--- a/packages/light/src/utils/find-routes.ts
+++ b/packages/light/src/utils/find-routes.ts
@@ -6,7 +6,10 @@ const globAsync = promisify(glob);
 
 export default async (rootPath: string): Promise<string[]> => {
   const routesDir = join(rootPath, './routes');
-  const routes = await globAsync('**/*.js', { cwd: routesDir });
+  const routes = await globAsync('**/*.js', {
+    cwd: routesDir,
+    ignore: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
+  });
 
   return routes;
 };


### PR DESCRIPTION
Follow the same glob as Jest by default. In the future we should allow customization of this.

closes #62 