### PR TITLE
Fix bug with middleware

### DIFF
--- a/packages/@lightjs/utils/src/apply-middleware/index.ts
+++ b/packages/@lightjs/utils/src/apply-middleware/index.ts
@@ -3,4 +3,5 @@ import { HandlerFunction, Middleware } from '@lightjs/types';
 export const applyMiddleware = (
   middleware: Middleware[],
   handler: HandlerFunction,
-): HandlerFunction => middleware.reverse().reduce((acc: any, val: any): any => val(acc), handler);
+): HandlerFunction =>
+  [...middleware].reverse().reduce((acc: any, val: any): any => val(acc), handler);


### PR DESCRIPTION
Calling `.reverse()` mutates the original array. We need to duplicate the array before mutating it otherwise it flips the middleware order every time `applyMiddleware` is called