### PR TITLE
Fix UseLogger

### DIFF
--- a/packages/@lightjs/config/src/importConfig/index.ts
+++ b/packages/@lightjs/config/src/importConfig/index.ts
@@ -1,28 +1,30 @@
 import { CreateConfig, CreateLoggerConfig, CreateMiddlewareConfig } from '@lightjs/types';
 import { join } from 'path';
-import { importFile } from '../utils/importFile';
+import { importTSorJSFile } from '../utils/importFile';
 
 export function importLightConfig(): CreateConfig | null {
-  return importFile('light.config.ts') || importFile('light.config.js') || null;
+  return importTSorJSFile('light.config');
 }
 
-export function importConfigFile(nameWithoutExtension: string) {
-  const config = importLightConfig();
-  // If the logger is imported in the light.config.ts file, we end up with a circular dependency.
-  // As a result, the `require` returns an empty object. We can just return null in that case and use the console logger.
-  if (typeof config !== 'function') return null;
-  const configDir = join(config?.().sourceDir || process.cwd(), 'config');
-  const file =
-    importFile(join(configDir, `${nameWithoutExtension}.ts`)) ||
-    importFile(join(configDir, `${nameWithoutExtension}.js`));
-  if (!file) return null;
-  return file;
+/**
+ * Imports a file from either the root or src directory.
+ */
+export function importProjectFile(relativePathWithoutExtension: string) {
+  const cwd = process.cwd();
+  const rootDir = join(cwd);
+  const srcDir = join(cwd, 'src');
+
+  return (
+    importTSorJSFile(join(rootDir, relativePathWithoutExtension)) ||
+    importTSorJSFile(join(srcDir, relativePathWithoutExtension)) ||
+    null
+  );
 }
 
 export function importLoggerConfig(): CreateLoggerConfig | null {
-  return importConfigFile('_logger');
+  return importProjectFile('config/_logger');
 }
 
 export function importMiddlewareConfig(): CreateMiddlewareConfig | null {
-  return importConfigFile('_middleware');
+  return importProjectFile('config/_middleware');
 }

--- a/packages/@lightjs/config/src/utils/importFile.ts
+++ b/packages/@lightjs/config/src/utils/importFile.ts
@@ -1,14 +1,15 @@
 import { existsSync } from 'fs';
-import { join } from 'path';
 
-export const importFile = (fileName: string) => {
-  const path = process.cwd();
-  const file = join(path, fileName);
-  if (existsSync(file)) {
-    let conf = require(file); // eslint-disable-line
+function importFile(fileName: string) {
+  if (existsSync(fileName)) {
+    let conf = require(fileName); // eslint-disable-line
     if (!conf) return null;
     if (conf.default) conf = conf.default;
     return conf;
   }
   return null;
-};
+}
+
+export function importTSorJSFile(fileName: string) {
+  return importFile(`${fileName}.ts`) || importFile(`${fileName}.js`);
+}

--- a/packages/@lightjs/router/src/createRouter/index.ts
+++ b/packages/@lightjs/router/src/createRouter/index.ts
@@ -1,13 +1,22 @@
 import Router from 'find-my-way';
-import { join } from 'path';
 import { CreateRouterOptions } from '@lightjs/types';
 import { createError } from 'micro';
-import { importLightConfig } from '@lightjs/config';
 import { convertHandlerFunctionToRequestHandler, applyMiddleware } from '@lightjs/utils';
-
+import { join } from 'path';
+import { existsSync } from 'fs';
 import { findRouteFiles } from '../utils/findRouteFiles';
 import { importRouteFiles } from '../utils/importRouteFiles';
 import { injectRouteIntoRouter } from '../utils/injectRouteIntoRouter';
+
+function findRoutesFolder() {
+  const cwd = process.cwd();
+  const rootDir = join(cwd, 'routes');
+  const srcDir = join(cwd, 'src', 'routes');
+
+  if (existsSync(rootDir)) return rootDir;
+  if (existsSync(srcDir)) return srcDir;
+  return rootDir;
+}
 
 export function createRouter({ middleware = [] }: CreateRouterOptions) {
   // create find-my-way router with default 404 handler
@@ -22,13 +31,11 @@ export function createRouter({ middleware = [] }: CreateRouterOptions) {
     defaultRoute,
   });
 
-  const cwd = process.cwd();
-  const config = importLightConfig()?.();
-  const rootPath = join(cwd, config?.sourceDir ? config.sourceDir : './');
+  const routesDirPath = findRoutesFolder();
 
   const fillRouter = () => {
-    const routeFiles = findRouteFiles(rootPath);
-    const importedRoutes = importRouteFiles(routeFiles, rootPath);
+    const routeFiles = findRouteFiles(routesDirPath);
+    const importedRoutes = importRouteFiles(routeFiles, routesDirPath);
     injectRouteIntoRouter(router, importedRoutes, { middleware });
     return importedRoutes;
   };

--- a/packages/@lightjs/router/src/utils/findRouteFiles.ts
+++ b/packages/@lightjs/router/src/utils/findRouteFiles.ts
@@ -1,10 +1,8 @@
-import { join } from 'path';
 import { sync as globSync } from 'glob';
 
-export function findRouteFiles(rootPath: string) {
-  const routesDir = join(rootPath, './routes');
+export function findRouteFiles(routesDirPath: string) {
   const routes = globSync('**/*.[jt]s', {
-    cwd: routesDir,
+    cwd: routesDirPath,
     // TODO: allow configuration of ignore
     ignore: ['**/__tests__/**/*.[jt]s?(x)', '**/?*.+(spec|test).[tj]s?(x)'],
   });

--- a/packages/@lightjs/router/src/utils/importRouteFiles.ts
+++ b/packages/@lightjs/router/src/utils/importRouteFiles.ts
@@ -2,12 +2,10 @@ import { join, parse } from 'path';
 import { ImportedRoute } from '@lightjs/types';
 import { convertFileNameToPath } from './convertFileNameToPath';
 
-export function importRouteFiles(routes: string[], rootPath: string) {
-  const routesDir = join(rootPath, './routes');
-
+export function importRouteFiles(routes: string[], routesDirPath: string) {
   const routeObjects: ImportedRoute[] = [];
   routes.forEach((route: string): void => {
-    const routePath = join(routesDir, route);
+    const routePath = join(routesDirPath, route);
 
     let handler = require(routePath); // eslint-disable-line
     if (handler.default) {

--- a/packages/@lightjs/types/src/config.ts
+++ b/packages/@lightjs/types/src/config.ts
@@ -1,9 +1,7 @@
 import { Middleware } from './createRoute';
 import { Logger } from './logger';
 
-export type Config = {
-  sourceDir?: string;
-};
+export type Config = {};
 
 export type CreateConfig = () => Config;
 


### PR DESCRIPTION
This PR removes the option to configure the source directory and just assumes it's either the root or src. Note that Next.js also does this: https://nextjs.org/docs/advanced-features/src-directory and the user can easily just move the light.config.js around to their desired location